### PR TITLE
Fix license text

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -128,4 +128,4 @@ Ensure all required environment variables (mainly AI service related) are correc
 
 ## License
 
-[MIT License](LICENSE)
+[Apache License 2.0](LICENSE)


### PR DESCRIPTION
## Summary
- update README.en.md to reference the Apache License 2.0

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6841c0398104832cb957a341f2731b18